### PR TITLE
remove ecr login

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,6 @@ node {
 
         stage('Image') {
             docker.withRegistry("https://${env.ECR_REPOSITORY_URI}", { ->
-                sh '$(aws ecr get-login)'
                 docker.build('content-resolver', '--no-cache --pull --rm .').push(revision)
             })
         }


### PR DESCRIPTION
### What

Remove explicit ECR login command from build pipeline. We've rolled out the ECR credentials manager now - if we explicitly attempt to call docker login an error will now be thrown.

### How to review

Check the build for this branch is passing.

### Who can review

Anyone but myself.
